### PR TITLE
support source content for image.yaml; add option for specifying configuration file

### DIFF
--- a/concreate/cli.py
+++ b/concreate/cli.py
@@ -78,6 +78,10 @@ class Concreate(object):
                             default="image.yaml",
                             help="path to image descriptor file, default: image.yaml")
 
+        parser.add_argument('--config',
+                            default="~/.concreate",
+                            help="path to concreate configuration file, default: ~/.concreate")
+
         parser.add_argument('commands',
                             nargs='+',
                             choices=['generate', 'build'],
@@ -94,7 +98,8 @@ class Concreate(object):
         logger.debug("Running version %s", version)
 
         try:
-            tools.cfg = tools.parse_cfg()
+            tools.init_cfg(self.args.config)
+            logger.debug("concreate configuration: %s" % (tools.cfg))
             tools.cleanup(self.args.target)
 
             # We need to construct Generator first, because we need overrides

--- a/concreate/generator.py
+++ b/concreate/generator.py
@@ -59,13 +59,6 @@ class Generator(object):
                 # copy image source
                 ignored_paths = set()
                 ignored_paths.add(str(self.target))
-                for repo in descriptor.get('modules', {}).get('repositories', {}):
-                    if 'path' in repo:
-                        repo_path = repo['path']
-                        if not os.path.isabs(repo_path):
-                            repo_path = str(os.path.join(descriptor.directory,
-                                                         repo_path))
-                        ignored_paths.add(repo_path)
                 logger.debug("Ignored paths for source copy: %s"
                              % (ignored_paths))
 

--- a/concreate/generator.py
+++ b/concreate/generator.py
@@ -182,11 +182,17 @@ class Generator(object):
                     os.makedirs(target_dir)
                 logger.info("Handling additional repository files...")
 
-                for url in urls.split(','):
-                    Resource.new({'url': url}).copy(target_dir)
-                    added_repos.append(os.path.splitext(
-                        os.path.basename(url))[0])
+                try:
+                    cwd = os.getcwd()
+                    os.chdir(os.path.abspath(os.path.dirname(tools.cfg.file)))
+                    for url in urls.split(','):
+                        Resource.new({'url': url}).copy(target_dir)
+                        added_repos.append(os.path.splitext(
+                            os.path.basename(url))[0])
 
-                logger.debug("Additional repository files handled")
+                    logger.debug("Additional repository files handled")
 
-                self.descriptor['additional_repos'] = added_repos
+                    self.descriptor['additional_repos'] = added_repos
+                finally:
+                    os.chdir(cwd)
+

--- a/concreate/resource.py
+++ b/concreate/resource.py
@@ -146,6 +146,7 @@ class Resource(object):
         parsedUrl = urlparse(url)
 
         if parsedUrl.scheme == 'file' or not parsedUrl.scheme:
+            logger.debug("Copying file url from: %s" % (parsedUrl.path))
             if os.path.isdir(parsedUrl.path):
                 shutil.copytree(parsedUrl.path, destination)
             else:

--- a/concreate/schema/image.yaml
+++ b/concreate/schema/image.yaml
@@ -1,3 +1,10 @@
 # To be merged with common.yaml
 map:
   from: {type: str, required: True}
+  version: {type: text, required: False}
+  execute:
+    seq:
+      - map:
+          script: {type: str}
+          user: {type: str}
+  source: {type: str}

--- a/concreate/templates/template.jinja
+++ b/concreate/templates/template.jinja
@@ -104,8 +104,7 @@ VOLUME ["{{ volume }}"]
 {% endif %}
 
 USER {{ run['user'] }}
-
-{% if run %}
+{%+ if run %}
 {%- if 'workdir' in run %}
 # Specify the working directory
 WORKDIR {{ run['workdir'] }}

--- a/concreate/templates/template.jinja
+++ b/concreate/templates/template.jinja
@@ -69,7 +69,7 @@ RUN rm{% for repo in additional_repos %} /etc/yum.repos.d/{{ repo }}.repo{% endf
 # Add all artifacts to the /tmp/artifacts
 # directory
 COPY \
-{% for artifact in artifacts %}
+{% for artifact in artifacts.values() %}
     {{ artifact['name'] }} \
     {% endfor %}
     /tmp/artifacts/

--- a/concreate/tools.py
+++ b/concreate/tools.py
@@ -16,10 +16,14 @@ logger = logging.getLogger('concreate')
 cfg = {}
 
 
-def parse_cfg():
+def init_cfg(config_file):
+    config_file = os.path.expanduser(config_file)
+    logger.info("Using concreate configuration file: %s" % (config_file))
     cp = configparser.ConfigParser()
-    cp.read(os.path.expanduser('~/.concreate'))
-    return cp._sections
+    cp.read(config_file)
+    global cfg
+    cfg = cp._sections
+    cfg.file = config_file
 
 
 def cleanup(target):

--- a/concreate/tools.py
+++ b/concreate/tools.py
@@ -124,9 +124,6 @@ def merge_lists(list1, list2):
     list1_dicts = [x for x in list1 if isinstance(x, dict)]
     for v2 in list2:
         if isinstance(v2, dict):
-            if 'name' not in v2:
-                raise KeyError("The 'name' key was not found in dict: %s" % v2)
-
             if v2['name'] not in [x['name'] for x in list1_dicts]:
                 list1.append(v2)
             else:

--- a/image.yaml
+++ b/image.yaml
@@ -1,0 +1,33 @@
+name: "redhat-concreate-1/concreate-openshift"
+description: "Source To Image (S2I) builder for images defined with concreate image.yaml files"
+version: "1.0"
+schema_version: 1
+
+from: "jboss/base-rhel7:latest"
+
+labels:
+- name: "io.openshift.s2i.scripts-url"
+  value: "image:///usr/libexec/s2i"
+- name: io.openshift.s2i.destination
+  value: "/tmp"
+
+run:
+  user: 185
+  workdir: "/home/jboss"
+  cmd:
+  - "/usr/libexec/s2i/run"
+
+packages:
+  repositories:
+  - jboss-rhel-os.repo
+  - jboss-rhel-server-extras.repo
+  install:
+  - python-setuptools
+  - git
+  - docker
+
+source: .
+
+execute:
+- script: image/install-concreate
+- script: image/build-image

--- a/image/added/build.sh
+++ b/image/added/build.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# This script executes either a 'concreate build' or
+# 'concreate generate; docker build -t <tag>' depending on whether or not an
+# OUTPUT_IMAGE is specified or not.  The following variables are used by this
+# script:
+#       OUTPUT_IMAGE: optional.  The name of for the image being built.  If not
+#               specified the default image name specified through concreate
+#               will be used and the image will not be pushed to any repository.
+#               This may be used for local builds.
+#       OUTPUT_REGISTRY: optional.  The name of the registry to use for the tag.
+#               This is used in conjunction with OUTPUT_IMAGE to generate the
+#               tag, e.g. OUTPUT_REGISTRY/OUTPUT_IMAGE.
+#       NO_PUSH: optional.  A non-empty value prevents the docker push
+#               operation.
+#       SOURCE_REPOSITORY: required.  The location of the source git repository
+#               to clone.
+#       SOURCE_REF: optional.  The git reference to use when building the image.
+#       CONCREATE_CFG_PATH: optional.  The location of the .concreate
+#               configuration file.
+#       PUSH_DOCKERCFG_PATH: required to push image to target repository.
+#               Specifies the path to the .docker/ directory containing the
+#               docker configuration to be used during docker push.
+#
+# The following volumes locations may be required to build the image:
+#       /var/run/docker.sock - This is required to build the image and can be
+#               specified as '-v /var/run/docker.sock'.
+#       CONCREATE_CFG_PATH - specify a volume to use your local configuration
+#               file (typically ~/.concreate), where
+#               CONCREATE_CFG_PATH == -v option.
+#       PUSH_DOCKERCFG_PATH - specify a volume to use your local docker
+#               configuration file (typically ~/.docker), where
+#               PUSH_DOCKERCFG_PATH == -v option.
+#       Additional .repo files - local files should be located in a sibling
+#               directory next to .concreate when mounted in the image, e.g.
+#               '-v ~/repos:${CONCREATE_CFG_PATH}/repos'
+#
+# Common issues:
+#       Permission denied on mounted volumes: you may have to add :Z to the
+#               volume parameters.
+#        Cannot connect to the Docker daemon. Is the docker daemon running on
+#               this host?: you may have to use the --privileged flag so the
+#               container has access to the docker.sock.
+#
+
+set -o pipefail
+IFS=$'\n\t'
+
+DOCKER_SOCKET=/var/run/docker.sock
+
+if [ ! -e "${DOCKER_SOCKET}" ]; then
+  echo "Docker socket missing at ${DOCKER_SOCKET}"
+  exit 1
+fi
+
+if [ -n "${OUTPUT_IMAGE}" ]; then
+  TAG="${OUTPUT_REGISTRY:+${OUTPUT_REGISTRY}/}${OUTPUT_IMAGE}"
+  echo "using tag: ${TAG}"
+else
+  echo "No output image specified.  Image will not be tagged."
+fi
+
+if [[ "${SOURCE_REPOSITORY}" = "http://*" ]] || [[ "${SOURCE_REPOSITORY}" = "https://*" ]]; then
+  curl --head --silent --fail --location --max-time 16 ${SOURCE_REPOSITORY} > /dev/null
+  if [ $? != 0 ]; then
+    echo "Could not access source url: ${SOURCE_REPOSITORY}"
+    exit 1
+  fi
+fi
+
+BUILD_DIR=$(mktemp --directory)
+git clone --recursive "${SOURCE_REPOSITORY}" "${BUILD_DIR}"
+if [ $? != 0 ]; then
+  echo "Error trying to fetch git source: ${SOURCE_REPOSITORY}"
+  exit 1
+fi
+
+pushd "${BUILD_DIR}"
+
+if [ -n "${SOURCE_REF}" ]; then
+  git checkout "${SOURCE_REF}"
+  if [ $? != 0 ]; then
+    echo "Error trying to checkout branch: ${SOURCE_REF}"
+    exit 1
+  fi
+fi
+
+if [ -n "${SOURCE_CONTEXT_DIR}" ]; then
+  popd
+  pushd "${BUILD_DIR}/${SOURCE_CONTEXT_DIR}"
+fi
+
+if [ -n "$TAG" ]; then
+  concreate ${CONCREATE_CFG_PATH:+--config="${CONCREATE_CFG_PATH}"} generate
+  if [ $? != 0 ]; then
+    echo "Error generating Dockerfile with concreate"
+    exit 1
+  fi
+
+  pushd target/image
+  docker build ${TAG:+--tag="${TAG}"} .
+  if [ $? != 0 ]; then
+    echo "Error building generated Dockerfile"
+    exit 1
+  fi
+
+  if [ -n "$NO_PUSH" ]; then
+    exit 0
+  fi
+
+  docker ${PUSH_DOCKERCFG_PATH:+--config="${PUSH_DOCKERCFG_PATH}"} push ${TAG}
+  if [ $? != 0 ]; then
+    echo "Error pushing image: ${TAG}"
+    exit 1
+  fi
+else
+  echo "No image tag specified.  Resulting image will not be pushed to any registry"
+  concreate ${CONCREATE_CFG_PATH:+--config="${CONCREATE_CFG_PATH}"} build
+  if [ $? != 0 ]; then
+    echo "Error building image with concreate"
+    exit 1
+  fi
+fi

--- a/image/added/concreate/default.concreate
+++ b/image/added/concreate/default.concreate
@@ -1,0 +1,10 @@
+[common]
+# ssl_verify = False
+# cache_url = http://cacher.example.com/get?#algorithm#=#hash#
+
+[repositories]
+jboss-rhel-os.repo = repos/jboss-rhel-os.repo
+jboss-rhel-ose.repo = repos/jboss-rhel-ose.repo
+jboss-rhel-rhscl.repo = repos/jboss-rhel-rhscl.repo
+jboss-rhel-optional.repo = repos/jboss-rhel-optional.repo
+jboss-rhel-extras.repo = repos/jboss-rhel-server-extras.repo

--- a/image/added/concreate/repos/jboss-rhel-extras.repo
+++ b/image/added/concreate/repos/jboss-rhel-extras.repo
@@ -1,0 +1,6 @@
+[jboss-rhel-extras]
+name=Red Hat RHEL7 extras repo
+baseurl=
+enabled=1
+gpgcheck=1
+gpgkey=

--- a/image/added/concreate/repos/jboss-rhel-optional.repo
+++ b/image/added/concreate/repos/jboss-rhel-optional.repo
@@ -1,0 +1,6 @@
+[jboss-rhel-optional]
+name=Red Hat RHEL7 optional repo
+baseurl=
+enabled=1
+gpgcheck=1
+gpgkey=

--- a/image/added/concreate/repos/jboss-rhel-os.repo
+++ b/image/added/concreate/repos/jboss-rhel-os.repo
@@ -1,0 +1,6 @@
+[jboss-rhel-os]
+name=Red Hat RHEL7 repo
+baseurl=
+enabled=1
+gpgcheck=1
+gpgkey=

--- a/image/added/concreate/repos/jboss-rhel-ose.repo
+++ b/image/added/concreate/repos/jboss-rhel-ose.repo
@@ -1,0 +1,7 @@
+[jboss-rhel-ose]
+name=Red Hat RHEL7 OSE 3.6 repo
+baseurl=
+enabled=1
+gpgcheck=1
+gpgkey=
+

--- a/image/added/concreate/repos/jboss-rhel-rhscl.repo
+++ b/image/added/concreate/repos/jboss-rhel-rhscl.repo
@@ -1,0 +1,6 @@
+[jboss-rhel-rhscl]
+name=Red Hat RHEL7 SCL repo
+baseurl=
+enabled=1
+gpgcheck=1
+gpgkey=

--- a/image/added/s2i/assemble
+++ b/image/added/s2i/assemble
@@ -1,0 +1,47 @@
+#!/bin/sh
+# This script executes either a 'concreate generate' producing a Dockerfile and
+# folder structure containing required resources to build the Dockerfile.  The
+# following variables are used by this script:
+#       SOURCE_REPOSITORY: required.  The location of the source git repository
+#               to clone.
+#       SOURCE_REF: optional.  The git reference to use when building the image.
+#       TARGET_DIR: optional.  The directory to place the generated image files.
+#       CONCREATE_CFG_PATH: optional.  The location of the .concreate
+#               configuration file.
+#
+# The following volumes locations may be required to build the image:
+#       CONCREATE_CFG_PATH - specify a volume to use your local configuration
+#               file (typically ~/.concreate), where
+#               CONCREATE_CFG_PATH == -v option.
+#       Additional .repo files - local files should be located in a sibling
+#               directory next to .concreate when mounted in the image, e.g.
+#               '-v ~/repos:${CONCREATE_CFG_PATH}/repos'
+#
+
+set -ex
+
+# /tmp is specified in io.openshift.s2i.destination label
+# restore build artifacts
+if [ "$(ls /tmp/artifacts/ 2>/dev/null)" ]; then
+    mv /tmp/artifacts/* /home/jboss/.
+fi
+
+# move the application source
+mv /tmp/src /home/jboss/src
+
+TARGET_DIR=${TARGET_DIR:-/home/jboss/target}
+CONCREATE_CFG_PATH=${CONCREATE_CFG_PATH:-/etc/concreate/default.concreate}
+
+mkdir -p "${TARGET_DIR}"
+
+pushd "/home/jboss/src"
+
+concreate --config="${CONCREATE_CFG_PATH}" --target="${TARGET_DIR}" generate
+if [ $? != 0 ]; then
+  echo "Error generating image files with concreate"
+  exit 1
+fi
+
+popd
+
+chown -R jboss:root "${TARGET_DIR}"

--- a/image/added/s2i/run
+++ b/image/added/s2i/run
@@ -1,0 +1,3 @@
+#!/bin/sh
+$(dirname $0)/usage
+exit 1

--- a/image/added/s2i/save-artifacts
+++ b/image/added/s2i/save-artifacts
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+pushd /home/jboss
+
+if [ -d target ]
+    tar -cf - target
+fi
+
+popd

--- a/image/added/s2i/usage
+++ b/image/added/s2i/usage
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+cat <<EOF
+This is a S2I which uses concreate to generate a Dockerfile and associated
+scripts, resources, etc. from concreate metadata, i.e. an image.yaml file.
+
+The resulting artifact can be built using standard docker build.
+
+This image is intended to be used as the first step in a chain, building the
+Dockerfile and collecting all supporting resources, with the next step building
+the image from these resources.
+EOF

--- a/image/build-image
+++ b/image/build-image
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Add s2i scripts and make the image S2I-enabled
+set -e
+
+SCRIPT_DIR=$(dirname $0)
+ADDED_DIR=${SCRIPT_DIR}/added
+CONCREATE_DIR=/etc/concreate
+S2I_DIR=/usr/libexec/s2i
+
+mkdir -p $CONCREATE_DIR
+mkdir -p $S2I_DIR
+
+chown -R jboss:root $SCRIPT_DIR
+chmod -R g+rwX $SCRIPT_DIR
+
+cp -r ${ADDED_DIR}/s2i/* ${S2I_DIR}
+cp -r ${ADDED_DIR}/concreate/* ${CONCREATE_DIR}
+
+chmod -R ug+x ${S2I_DIR}/*
+
+# Add jboss user to root group
+usermod -g root -G jboss jboss
+
+# Configure $HOME
+chown -R jboss:root /home/jboss

--- a/image/install-concreate
+++ b/image/install-concreate
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Install concreate into the image
+set -e
+
+IMAGE_DIR=$(dirname $0)
+
+pushd "${IMAGE_DIR}/.."
+python setup.py install
+popd

--- a/openshift/image-stream.yaml
+++ b/openshift/image-stream.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ImageStream
+metadata:
+  name: concreate
+  annotations:
+    openshift.io/display-name: Concreate 1.0
+spec:
+  tags:
+  - name: "1.0"
+    annotations:
+      description: Build images defined using concreate image.yaml files.
+      iconClass: icon-jboss
+      openshift.io/display-name: Concreate 1.0
+      supports: concreate:1.0
+      tags: builder,xpaas,concreate
+      version: "1.0"
+    from:
+      kind: DockerImage
+      name: redhat-concreate-1/concreate-openshift:1.0

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -1,0 +1,141 @@
+kind: Template
+apiVersion: v1
+labels:
+  template: concreate-s2i
+message: A new image has been added to your project.
+metadata:
+  annotations:
+    description: Create concreate based images using OpenShift S2I.
+    iconClass: icon-jboss
+    "openshift.io/display-name": Concreate 1.0
+    tags: xpaas, concreate
+    version: "1.0"
+  name: concreate-s2i
+objects:
+- kind: ImageStream
+  apiVersion: v1
+  metadata:
+    name: ${IMAGE_NAME}-source
+    labels:
+      concreate: ${IMAGE_NAME}-${IMAGE_TAG}
+- kind: ImageStream
+  apiVersion: v1
+  metadata:
+    name: ${IMAGE_NAME}
+    labels:
+      concreate: ${IMAGE_NAME}-${IMAGE_TAG}
+- kind: BuildConfig
+  apiVersion: v1
+  metadata:
+    name: ${IMAGE_NAME}-source-${IMAGE_TAG}
+    labels:
+      concreate: ${IMAGE_NAME}-${IMAGE_TAG}
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: ${IMAGE_NAME}-source:${IMAGE_TAG}
+    source:
+      secrets:
+      - secret:
+          name: concreate-config
+        destinationDir: /etc/concreate
+      contextDir: ${CONTEXT_DIR}
+      git:
+        ref: ${SOURCE_REPOSITORY_REF}
+        uri: ${SOURCE_REPOSITORY_URL}
+      type: Git
+    strategy:
+      sourceStrategy:
+        forcePull: true
+        from:
+          kind: ImageStreamTag
+          name: concreate:1.0
+          namespace: ${IMAGE_STREAM_NAMESPACE}
+        env:
+        - name: CONCREATE_CFG_PATH
+          value: /etc/concreate/.concreate
+      type: Source
+    triggers:
+    - type: GitHub
+      github:
+        secret: ${GITHUB_WEBHOOK_SECRET}
+    - type: Generic
+      generic:
+        secret: ${GENERIC_WEBHOOK_SECRET}
+    - type: ConfigChange
+- kind: BuildConfig
+  apiVersion: v1
+  metadata:
+    name: ${IMAGE_NAME}-${IMAGE_TAG}
+    labels:
+      concreate: ${IMAGE_NAME}-${IMAGE_TAG}
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: ${IMAGE_NAME}:${IMAGE_TAG}
+    source:
+      images:
+      - from:
+          kind: ImageStreamTag
+          name: ${IMAGE_NAME}-source:${IMAGE_TAG}
+        paths:
+        - sourcePath: /home/jboss/target/image/.
+          destinationDir: .
+      secrets:
+      - secret:
+          name: package-repos
+        destinationDir: repos
+      type: Image
+    strategy:
+      dockerStrategy:
+      type: Docker
+    triggers:
+    - type: ImageChange
+      imageChange:
+        from:
+          kind: ImageStreamTag
+          name: ${IMAGE_NAME}-source:${IMAGE_TAG}
+    - type: Generic
+      generic:
+        secret: ${GENERIC_WEBHOOK_SECRET}
+    - type: ConfigChange
+parameters:
+- name: IMAGE_NAME
+  displayName: Image Name
+  description: The name for the image.
+  required: true
+- name: IMAGE_TAG
+  description: The tag for the image.
+  displayName: Image Tag
+  value: latest
+  required: true
+- name: SOURCE_REPOSITORY_URL
+  displayName: Git Repository URL
+  description: Git source URI for application
+  value: https://github.com/jboss-container-images/
+  required: true
+- name: SOURCE_REPOSITORY_REF
+  displayName: Git Reference
+  description: Git branch/tag reference
+- name: CONTEXT_DIR
+  displayName: Context Directory
+  description: Path within Git project to build; empty for root project directory.
+- name: IMAGE_STREAM_NAMESPACE
+  displayName: ImageStream Namespace
+  description: Namespace in which the ImageStreams for Red Hat Middleware images are installed. These ImageStreams are normally installed in the openshift namespace. You should only need to modify this if you've installed the ImageStreams in a different namespace/project."
+  value: openshift
+  required: true
+- name: GITHUB_WEBHOOK_SECRET
+  displayName: Github Webhook Secret
+  description: GitHub trigger secret
+  from: '[a-zA-Z0-9]{8}'
+  generate: expression
+  required: true
+- name: GENERIC_WEBHOOK_SECRET
+  displayName: Generic Webhook Secret
+  description: Generic build trigger secret
+  from: '[a-zA-Z0-9]{8}'
+  generate: expression
+  required: true

--- a/tests/test_unit_descriptor.py
+++ b/tests/test_unit_descriptor.py
@@ -12,13 +12,13 @@ class TestDescriptor(unittest.TestCase):
     def test_descriptor_schema_version(self):
         img_descriptor = descriptor.Descriptor.__new__(descriptor.Descriptor)
         img_descriptor.descriptor = {'schema_version': 1}
-        img_descriptor.check_schema_version()
+        img_descriptor.check_schema_version("dummy/path")
 
     def test_descriptor_schema_version_bad_version(self):
         img_descriptor = descriptor.Descriptor.__new__(descriptor.Descriptor)
         img_descriptor.descriptor = {'schema_version': 123}
         with self.assertRaises(ConcreateError):
-            img_descriptor.check_schema_version()
+            img_descriptor.check_schema_version("dummy/path")
 
 
 class TestLabels(unittest.TestCase):


### PR DESCRIPTION
This fixes a few issues with merging, which was causing exceptions when artifacts were defined in multiple modules.  It also adds support for defining a ``source`` attribute in image.yaml, which effectively turns image.yaml into a full fledged module, with the source content copied into the image's module folder.

I'm working on putting together a builder image for concreate, which will use this new approach for defining an image that does not include any modules.  See issue #49.

This also adds a --config option so you can specify a different configuration file.  This is required so a configuration file can be specified within the builder image.