### PR TITLE
Simplified merging code

### DIFF
--- a/concreate/descriptor.py
+++ b/concreate/descriptor.py
@@ -72,7 +72,7 @@ class Descriptor(object):
           descriptor - a concreate descritor
         """
         try:
-            self.descriptor = concreate.tools.merge_dictionaries(self.descriptor, descriptor)
+            self.descriptor = concreate.tools.merge_descriptors(self.descriptor, descriptor)
         except KeyError as ex:
             logger.debug(ex, exc_info=True)
             raise ConcreateError("Cannot merge descriptors, see log message for more information")
@@ -128,6 +128,11 @@ class Label(Descriptor):
 
 
 class Env(Descriptor):
+    """Object representing Env variable
+
+    Args:
+      descriptor - yaml object containing Env variable
+    """
     def __init__(self, descriptor):
         self.schemas = [yaml.safe_load("""
         map:

--- a/concreate/module.py
+++ b/concreate/module.py
@@ -5,7 +5,6 @@ import shutil
 from concreate import tools
 from concreate.descriptor import Module
 from concreate.errors import ConcreateError
-from concreate.resource import Resource
 
 logger = logging.getLogger('concreate')
 # importable list of all modules


### PR DESCRIPTION
Now we are working with Descriptor classes instead of dictionaires for
merging, so we can move merging logic to the domain of descriptor class