### PR TITLE
Parametrizing config file location

### DIFF
--- a/concreate/builders/osbs.py
+++ b/concreate/builders/osbs.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 
 from builtins import input
+from concreate import tools
 from concreate.builder import Builder
 from concreate.errors import ConcreateError
 
@@ -40,7 +41,7 @@ class OSBSBuilder(Builder):
             raise ConcreateError(
                 "OSBS builder needs repostiory and branch provided!")
 
-        self.dist_git_dir = os.path.join(os.path.expanduser('~/.concreate.d'),
+        self.dist_git_dir = os.path.join(os.path.expanduser(tools.cfg['common']['work_dir']),
                                          'osbs',
                                          repository)
         if not os.path.exists(os.path.dirname(self.dist_git_dir)):

--- a/concreate/cli.py
+++ b/concreate/cli.py
@@ -46,6 +46,10 @@ class Concreate(object):
                             action='version',
                             help='show version and exit', version=version)
 
+        parser.add_argument('--config',
+                            default='~/.concreate',
+                            help='path for concreate config file (~/.concreate is default)')
+
         test_group = parser.add_argument_group('test',
                                                "Arguments valid for the 'test' target")
 
@@ -130,7 +134,7 @@ class Concreate(object):
         logger.debug("Running version %s", version)
 
         try:
-            tools.cfg = tools.parse_cfg()
+            tools.cfg = tools.get_cfg(self.args.config)
             tools.cleanup(self.args.target)
 
             # We need to construct Generator first, because we need overrides

--- a/concreate/tools.py
+++ b/concreate/tools.py
@@ -15,10 +15,18 @@ logger = logging.getLogger('concreate')
 cfg = {}
 
 
-def parse_cfg():
+def get_cfg(config_path):
+    """Returns configuration from concreate config file and prepares sensible defaults
+
+    params:
+        config_path - path to a concreate config file (expanding user)
+    """
     cp = configparser.ConfigParser()
-    cp.read(os.path.expanduser('~/.concreate'))
-    return cp._sections
+    cp.read(os.path.expanduser(config_path))
+    cfg = cp._sections
+    cfg['common'] = cfg.get('common', {})
+    cfg['common']['work_dir'] = cfg.get('common').get('work_dir', '~/.concreate.d')
+    return cfg
 
 
 def cleanup(target):

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -4,12 +4,25 @@ Configuration file
 Concreate can be configured using a configuration file. We use the
 properties file format.
 
-Concreate will look for this file at the path ``~/.concreate``.
+Concreate will look for this file at the path ``~/.concreate``. Its location can be changed via command line ``--config`` option.
+
+**Example**
+Running Concreate with different config file:
+
+.. code:: sh
+	  
+	  $ concreate --config ~/alternative_path build
 
 Below you can find description of available sections together with options described in detail.
 
 ``[common]``
 ------------
+
+``work_dir``
+^^^^^^^^^^^^
+
+Contains location of Concreate working directory, which is used to store some persistent data like
+dist_git repositories.
 
 ``ssl_verify``
 ^^^^^^^^^^^^^^

--- a/tests/test_unit_args.py
+++ b/tests/test_unit_args.py
@@ -54,3 +54,19 @@ def test_args_osbs_user(mocker):
                                       'USER'])
 
     assert Concreate().parse().args.build_osbs_user == 'USER'
+
+
+def test_args_osbs_config_default(mocker):
+    mocker.patch.object(sys, 'argv', ['concreate',
+                                      'generate'])
+
+    assert Concreate().parse().args.config == '~/.concreate'
+
+
+def test_args_osbs_config(mocker):
+    mocker.patch.object(sys, 'argv', ['concreate',
+                                      '--config',
+                                      'whatever',
+                                      'generate'])
+
+    assert Concreate().parse().args.config == 'whatever'


### PR DESCRIPTION
Location of Concreate config file can now be parametrized via --config
option as follows:

``` sh
concreate --config path ...
```

If parameter is not specified it defaults to ~/.concreate

Config file also contains new common key `workdir` which specifies
working directory for concreate. Defaults to ~/.concreate.d

example
```
[common]
work_dir = ~/whatever
```

fixes #172