### PR TITLE
Fixed Image schema validaiton

### DIFF
--- a/concreate/descriptor/image.py
+++ b/concreate/descriptor/image.py
@@ -1,10 +1,11 @@
+import copy
 import yaml
 
 from concreate.descriptor import Descriptor, Label, Env, Port, Run, Modules, \
     Packages, Osbs, Volume, Resource
 from concreate.version import version as concreate_version
 
-image_schema = yaml.safe_load("""
+_image_schema = yaml.safe_load("""
 map:
   name: {type: str, required: True}
   version: {type: text, required: True}
@@ -23,11 +24,14 @@ map:
   volumes: {type: any}""")
 
 
+def get_image_schema():
+    return copy.deepcopy(_image_schema)
+
+
 class Image(Descriptor):
     def __init__(self, descriptor, directory):
         self.directory = directory
-        self.schemas = [image_schema.copy()]
-
+        self.schemas = [_image_schema.copy()]
         super(Image, self).__init__(descriptor)
         self.skip_merging = ['description',
                              'version',

--- a/concreate/descriptor/module.py
+++ b/concreate/descriptor/module.py
@@ -1,10 +1,10 @@
 import concreate
 
 from concreate.descriptor import Image, Execute
-from concreate.descriptor.image import image_schema
+from concreate.descriptor.image import get_image_schema
 
 
-module_schema = image_schema.copy()
+module_schema = get_image_schema()
 module_schema['map']['name'] = {'type': 'str'}
 module_schema['map']['version'] = {'type': 'text'}
 module_schema['map']['execute'] = {'type': 'any'}

--- a/concreate/descriptor/overrides.py
+++ b/concreate/descriptor/overrides.py
@@ -1,7 +1,7 @@
 from concreate.descriptor import Image
-from concreate.descriptor.image import image_schema
+from concreate.descriptor.image import get_image_schema
 
-overrides_schema = image_schema.copy()
+overrides_schema = get_image_schema()
 overrides_schema['map']['name'] = {'type': 'str'}
 overrides_schema['map']['version'] = {'type': 'text'}
 

--- a/tests/test_unit_descriptor.py
+++ b/tests/test_unit_descriptor.py
@@ -1,5 +1,7 @@
+import pytest
 import yaml
 
+from concreate.errors import ConcreateError
 from concreate.descriptor import Label, Port, Env, Volume, Packages, Image, Osbs
 
 
@@ -90,3 +92,10 @@ def test_image():
     assert image['name'] == 'test/foo'
     assert type(image['labels'][0]) == Label
     assert image['labels'][0]['name'] == 'test'
+
+
+def test_image_missing_name():
+    with pytest.raises(ConcreateError):
+        Image(yaml.safe_load("""
+        from: foo
+        version: 1.9"""), 'foo')

--- a/tests/test_unit_tools.py
+++ b/tests/test_unit_tools.py
@@ -17,7 +17,7 @@ class TestDescriptor(Descriptor):
 
 
 def test_merging_description_image():
-    desc1 = Image({'name': 'foo'}, None)
+    desc1 = Image({'name': 'foo', 'version': 1}, None)
 
     desc2 = Module({'name': 'mod1',
                     'description': 'mod_desc'}, None)
@@ -37,7 +37,7 @@ def test_merging_description_modules():
 
 
 def test_merging_description_override():
-    desc1 = Image({'name': 'foo'}, None)
+    desc1 = Image({'name': 'foo', 'version': 1}, None)
 
     desc2 = Overrides({'name': 'mod1',
                        'description': 'mod_desc'})


### PR DESCRIPTION
It seems that iamge_schema got overriden by override schema, so name
key was not mandatory.
I've fixed it by exposing only deep copy of image_schema.