### PR TITLE
com.redhat.component label is now generated only if not present in image descriptor

### DIFF
--- a/concreate/template_helper.py
+++ b/concreate/template_helper.py
@@ -24,13 +24,16 @@ class TemplateHelper(object):
             ret.append("\"%s\"" % cmd)
         return "[%s]" % ', '.join(ret)
 
-    def component(self, name):
-        """Returns the component name based on the image name"""
-
+    def component(self, name, labels):
+        """Constructs com.redhat.component LABEL only if its ont present"""
+        if labels:
+            for label in labels:
+                if label['name'] == 'com.redhat.component':
+                    return ""
         regex = re.sub(r'^(.*)/(.*)$', r'\1-\2-docker', name)
 
         # we don't want -tech-preview to be in component fields
-        return "%s" % regex.replace("-tech-preview", '')
+        return 'com.redhat.component="%s"' % regex.replace("-tech-preview", '')
 
     def base_image(self, base_image, version):
         """Return the base image name that could be used in FROM

--- a/concreate/templates/template.jinja
+++ b/concreate/templates/template.jinja
@@ -30,8 +30,8 @@ ENV JBOSS_IMAGE_NAME="{{name}}" \
 # Labels
 LABEL name="$JBOSS_IMAGE_NAME" \
       version="$JBOSS_IMAGE_VERSION" \
-      architecture="x86_64" \
-      com.redhat.component="{{ helper.component(name) }}" {%- if labels %} \
+      architecture="x86_64" {% if helper.component(name, labels) %} \
+      {{ helper.component(name, labels) }} {% endif %} {%- if labels %} \
       {% for label in labels %}
       {{ label.name }}="{{ label.value }}" {%- if loop.index < loop.length %} \{% endif %}
 

--- a/concreate/version.py
+++ b/concreate/version.py
@@ -1,2 +1,2 @@
-version = "1.4.0"
+version = "1.4.1"
 schema_version = 1

--- a/tests/test_unit_template_helper.py
+++ b/tests/test_unit_template_helper.py
@@ -1,21 +1,27 @@
-import unittest
-
+from concreate.descriptor.label import Label
 from concreate.template_helper import TemplateHelper
 
 
-class TestConfig(unittest.TestCase):
+helper = TemplateHelper()
 
-    def setUp(self):
-        self.helper = TemplateHelper()
 
-    def test_generate_component(self):
-        self.assertEqual(self.helper.component(
-            "jboss-eap-7/eap70"), "jboss-eap-7-eap70-docker")
+def test_generate_component():
+    component = helper.component("jboss-eap-7/eap70", None)
+    assert component == 'com.redhat.component="jboss-eap-7-eap70-docker"'
 
-    def test_generate_component_for_beta_image(self):
-        self.assertEqual(self.helper.component(
-            "jboss-eap-7-beta/eap70"), "jboss-eap-7-beta-eap70-docker")
 
-    def test_generate_component_for_tech_preview_image(self):
-        self.assertEqual(self.helper.component(
-            "jboss-eap-7-tech-preview/eap70"), "jboss-eap-7-eap70-docker")
+def test_generate_component_exists():
+    labels = [Label({'name': 'com.redhat.component',
+                     'value': 'foo'})]
+    component = helper.component("jboss-eap-7/eap70", labels)
+    assert component == ''
+
+
+def test_generate_component_for_beta_image():
+    component = helper.component("jboss-eap-7-beta/eap70", None)
+    assert component == 'com.redhat.component="jboss-eap-7-beta-eap70-docker"'
+
+
+def test_generate_component_for_tech_preview_image():
+    component = helper.component("jboss-eap-7-tech-preview/eap70", None)
+    assert component == 'com.redhat.component="jboss-eap-7-eap70-docker"'


### PR DESCRIPTION
com.redhat.component label is now generated only if not present in image descriptor

Signed-off-by: David Becvarik <dbecvari@redhat.com>